### PR TITLE
Add /norestart flag

### DIFF
--- a/duo-authentication/tools/chocolateyinstall.ps1
+++ b/duo-authentication/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 # Inject any custom parameters into the silentArgs
-$silentArgs   = '/S /V"/qn'
+$silentArgs   = '/S /V"/qn /norestart'
 $pp = Get-PackageParameters
 ForEach ($key in $pp.Keys) {
   $silentArgs += " $key=" + $pp[$key]


### PR DESCRIPTION
Thanks for maintaining this package! I had one small suggestion: the DUO installer currently will forceably restart the local machine if needed. This can be unpredictable. Adding the /norestart flag gives you flexibility to restart at your convenience. Also, from my testing duo doesn't really need a restart to become functional. The next time a user logs in it will be active. 

Doc source: https://help.duo.com/s/article/1090?language=en_US

> Optionally, you can run this command with other switches such as /norestart to prevent any pending restarts the machine may have.

Testing: 
- I had a machine with a previous version of duo, ran the installer and it automatically rebooted it. I reset the scenario and I changed the package to /norestart and this time it didn't reboot after upgrade. 

I didn't see a way to make an issue in this repo which is why I opted for a pull request. Thoughts? 