### PR TITLE
Update Silent Args to avoid reboots on upgrade.

### DIFF
--- a/duo-authentication/tools/chocolateyinstall.ps1
+++ b/duo-authentication/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 # Inject any custom parameters into the silentArgs
-$silentArgs   = '/S /V"/qn /norestart'
+$silentArgs   = '/S /V"REBOOT=ReallySuppress /qn /norestart'
 $pp = Get-PackageParameters
 ForEach ($key in $pp.Keys) {
   $silentArgs += " $key=" + $pp[$key]


### PR DESCRIPTION
We found that on both install or upgrade of the duo-authentication package, we were experiencing reboots until we updated the $silentargs to add the "REBOOT=ReallySuppress" option.

We found this flag documented here:
https://help.duo.com/s/article/4868?language=en_US

Paul
